### PR TITLE
DE-409 Add employee_history to hibob Meltano integration

### DIFF
--- a/tap_hibob/schemas/EmployeeHistory.py
+++ b/tap_hibob/schemas/EmployeeHistory.py
@@ -20,7 +20,6 @@ schema = th.PropertiesList(
     th.Property("type", th.StringType),
     th.Property("calendarName", th.StringType),
     th.Property("calendarId", th.IntegerType),
-    th.Property("flsaCode", th.IntegerType),
     th.Property("salaryPayType", th.StringType),
     th.Property("fte", th.IntegerType),
     th.Property("weeklyHours", th.IntegerType),

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -44,7 +44,7 @@ class EmployeeHistoryStream(HibobStream):
     path = "/v1/people/{employee_id}/employment"
     primary_keys = ["id", "employee_id"]
     records_jsonpath = "$.values[*]"
-    replication_key = "modificationDate"
+    replication_key = "creationDate"
     schema = EmployeeHistory.schema
     parent_stream_type = EmployeesStream
     ignore_parent_replication_keys = True


### PR DESCRIPTION
### Ticket ([DE-409](https://potloc.atlassian.net/browse/DE-409))

> Debuging Hibob bigquery direct integration has caused the removal of employee_history tracking

---
_from `tiguidou` with :heart:_
