### PR TITLE
BI-188-get-time-spent-per-employee-relative-to-actual-working-hours

### DIFF
--- a/tap_hibob/schemas/EmployeeHistory.py
+++ b/tap_hibob/schemas/EmployeeHistory.py
@@ -20,7 +20,6 @@ schema = th.PropertiesList(
     th.Property("type", th.StringType),
     th.Property("calendarName", th.StringType),
     th.Property("calendarId", th.IntegerType),
-    th.Property("flsaCode", th.IntegerType),
     th.Property("salaryPayType", th.StringType),
     th.Property("fte", th.IntegerType),
     th.Property("weeklyHours", th.IntegerType),

--- a/tap_hibob/schemas/EmployeeTimeOff.py
+++ b/tap_hibob/schemas/EmployeeTimeOff.py
@@ -1,0 +1,14 @@
+from singer_sdk import typing as th  # JSON Schema typing helpers
+
+schema = th.PropertiesList(
+    th.Property("requestId", th.IntegerType),
+    th.Property("changeType", th.StringType),
+    th.Property("startDate", th.StringType),
+    th.Property("endDate", th.StringType),
+    th.Property("startPortion", th.StringType),
+    th.Property("endPortion", th.StringType),
+    th.Property("policyTypeDisplayName", th.StringType),
+    th.Property("employeeDisplayName", th.StringType),
+    th.Property("employeeId", th.StringType),
+    th.Property("type", th.StringType),
+).to_dict()

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -11,7 +11,7 @@ from tap_hibob.client import HibobStream
 # TODO: Delete this is if not using json files for schema definition
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
-from tap_hibob.schemas import Employees, EmployeeHistory
+from tap_hibob.schemas import Employees, EmployeeHistory, EmployeeTimeOff
 
 
 class EmployeesStream(HibobStream):
@@ -44,7 +44,23 @@ class EmployeeHistoryStream(HibobStream):
     path = "/v1/people/{employee_id}/employment"
     primary_keys = ["id", "employee_id"]
     records_jsonpath = "$.values[*]"
-    replication_key = "modificationDate"
+    replication_key = "creationDate"
     schema = EmployeeHistory.schema
     parent_stream_type = EmployeesStream
     ignore_parent_replication_keys = True
+
+
+class EmployeeTimeOffStream(HibobStream):
+    name = "employee_time_off"
+    path = "/v1/timeoff/requests/changes"
+    primary_keys = ["requestId"]
+    records_jsonpath = "$.changes[*]"
+    replication_key = "startDate"
+    schema = EmployeeTimeOff.schema
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params["since"] = "2007-04-05T12:30-02:00"
+        return params

--- a/tap_hibob/tap.py
+++ b/tap_hibob/tap.py
@@ -6,11 +6,15 @@ from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 # TODO: Import your custom stream types here:
-from tap_hibob.streams import EmployeesStream, EmployeeHistoryStream
+from tap_hibob.streams import (
+    EmployeesStream,
+    EmployeeHistoryStream,
+    EmployeeTimeOffStream,
+)
 
 # TODO: Compile a list of custom stream types here
 #       OR rewrite discover_streams() below with your custom logic.
-STREAM_TYPES = [EmployeesStream, EmployeeHistoryStream]
+STREAM_TYPES = [EmployeesStream, EmployeeHistoryStream, EmployeeTimeOffStream]
 
 
 class TapHibob(Tap):


### PR DESCRIPTION
### Ticket ([BI-188](https://potloc.atlassian.net/browse/BI-188))

> Need behind ticket : delivery teams must log at least 50% of their time (20h/week) on Wrike, otherwise an alert appears.  When a team member goes on holidays, alerts pop up when they shouldn’t, since Wrike has no information on whether someone is on vacation. 
> 
> Goal : build dashboard with the logged hours of each member (filter by team) compared to the hours they worked that week. 

---
_from `tiguidou` with :heart:_
