### PR TITLE
DE-1094-add-team-manager-historical-data-in-hibob

### DIFF
--- a/tap_hibob/schemas/EmployeeWorkHistory.py
+++ b/tap_hibob/schemas/EmployeeWorkHistory.py
@@ -20,5 +20,14 @@ schema = th.PropertiesList(
     th.Property("site", th.StringType),
     th.Property("title", th.StringType),
     th.Property("department", th.StringType),
-    th.Property("workChangeType", th.StringType)
+    th.Property("workChangeType", th.StringType),
+    th.Property("reportsTo",
+        th.ObjectType(
+            th.Property("id", th.StringType),
+            th.Property("firstName", th.StringType),
+            th.Property("surname", th.StringType),
+            th.Property("email", th.StringType),
+            th.Property("displayName", th.StringType),
+        )
+    )
 ).to_dict()


### PR DESCRIPTION
### Ticket ([DE-1094](https://potloc.atlassian.net/browse/DE-1094))

> Hello [~accountid:6228b0014160640069ca439a],
> 
> I’m trying to get the historical changes of employee to direct_report programmatically. Ideally this would be added to the potloc-data.dbt_hibob.stg_hibob_hist_employee_team table

---
_from `tiguidou` with :heart:_


[DE-1094]: https://potloc.atlassian.net/browse/DE-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ