### PR TITLE
DE-1740 Tap-Hibob - Update authorization to allow 

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,6 +1,7 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: fadb6424-0b8b-4e32-9dab-c46ea2634ba8
+default_environment: dev
 plugins:
   extractors:
   - name: tap-hibob
@@ -15,14 +16,17 @@ plugins:
       kind: password
     - name: start_date
       value: '2010-01-01T00:00:00Z'
+    - name: service_account_id
+    - name: service_account_password
+      kind: password
     config:
       start_date: '2010-01-01T00:00:00Z'
     select:
-    # - employees.*
-    # - employee_history.*
-    # - employee_work_history.*
-    # - employee_time_off.*
-    - employee_payroll.*
+    - employees.*
+    - employee_history.*
+    - employee_work_history.*
+    - employee_time_off.*
+    # - employee_payroll.*
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -26,7 +26,11 @@ plugins:
     - employee_history.*
     - employee_work_history.*
     - employee_time_off.*
-    # - employee_payroll.*
+
+  - name: tap-hibob-finance
+    inherit_from: tap-hibob
+    select:
+    - employee_payroll.*
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -26,8 +26,15 @@ class HibobStream(RESTStream):
     next_page_token_jsonpath = "$.next_page"  # Or override `get_next_page_token`.
 
     @property
-    def authenticator(self) -> BasicAuthenticator:
+    def authenticator(self):
         """Return a new authenticator object."""
+        if self.config.get("authorization", False):
+            return APIKeyAuthenticator.create_for_stream(
+                self,
+                key="authorization",
+                value=self.config.get("authorization"),
+                location="header",
+            )
         return BasicAuthenticator.create_for_stream(
             self,
             username=self.config.get("service_account_id"),

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -8,7 +8,7 @@ from memoization import cached
 
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.streams import RESTStream
-from singer_sdk.authenticators import APIKeyAuthenticator
+from singer_sdk.authenticators import APIKeyAuthenticator, BasicAuthenticator
 
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
@@ -26,13 +26,12 @@ class HibobStream(RESTStream):
     next_page_token_jsonpath = "$.next_page"  # Or override `get_next_page_token`.
 
     @property
-    def authenticator(self) -> APIKeyAuthenticator:
+    def authenticator(self) -> BasicAuthenticator:
         """Return a new authenticator object."""
-        return APIKeyAuthenticator.create_for_stream(
+        return BasicAuthenticator.create_for_stream(
             self,
-            key="authorization",
-            value=self.config.get("authorization"),
-            location="header",
+            username=self.config.get("service_account_id"),
+            password=self.config.get("service_account_password"),
         )
 
     @property

--- a/tap_hibob/tap.py
+++ b/tap_hibob/tap.py
@@ -37,18 +37,18 @@ class TapHibob(Tap):
             "authorization",
             th.StringType,
             required=False,
-            description="DEPRECATED - Authorization token for Auth2.0",
+            description="Authorization token for Auth2.0",
         ),
         th.Property(
             "service_account_id",
             th.StringType,
-            required=True,
+            required=False,
             description="ID of service account.",
         ),
         th.Property(
             "service_account_password",
             th.StringType,
-            required=True,
+            required=False,
             description="Password for associated service account.",
         ),
         th.Property(

--- a/tap_hibob/tap.py
+++ b/tap_hibob/tap.py
@@ -36,8 +36,20 @@ class TapHibob(Tap):
         th.Property(
             "authorization",
             th.StringType,
+            required=False,
+            description="DEPRECATED - Authorization token for Auth2.0",
+        ),
+        th.Property(
+            "service_account_id",
+            th.StringType,
             required=True,
-            description="Authorization token for Auth2.0",
+            description="ID of service account.",
+        ),
+        th.Property(
+            "service_account_password",
+            th.StringType,
+            required=True,
+            description="Password for associated service account.",
         ),
         th.Property(
             "start_date",


### PR DESCRIPTION
### Ticket ([DE-1740](https://potloc.atlassian.net/browse/DE-1740))

> After rotating the service account, we realized that we did not currently have the correct authentication method - we should have been using username/password basic credentials.|
> 
> We will need to edit the basic authenticator: [https://sdk.meltano.com/en/latest/classes/singer_sdk.authenticators.BasicAuthenticator.html#singer_sdk.authenticators.BasicAuthenticator](https://sdk.meltano.com/en/latest/classes/singer_sdk.authenticators.BasicAuthenticator.html#singer_sdk.authenticators.BasicAuthenticator|smart-link) 
> 
> 
> 
> To take basic credentials, as well as change the terraform file to reflect this. 
> 
> Credentials can be found in 1password

---
_from `tiguidou` with :heart:_


[DE-1740]: https://potloc.atlassian.net/browse/DE-1740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ