### PR TITLE
DE-1934 Tap-hibob rate limit

### DIFF
--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -103,3 +103,4 @@ class HibobStream(RESTStream):
 
     def backoff_max_tries(self) -> int:
         return 6
+    asdasdasfsaf

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -103,5 +103,5 @@ class HibobStream(RESTStream):
 
     def backoff_max_tries(self) -> int:
         # https://sdk.meltano.com/en/latest/classes/singer_sdk.RESTStream.html#singer_sdk.RESTStream.backoff_max_tries
-        # Default value is set to 5 in the docs, upgrading to 6 
+        # Default value is set to 5 in the docs, upgrading to 6
         return 6

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -103,4 +103,3 @@ class HibobStream(RESTStream):
 
     def backoff_max_tries(self) -> int:
         return 6
-    asdasdasfsaf

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -102,4 +102,6 @@ class HibobStream(RESTStream):
         return row
 
     def backoff_max_tries(self) -> int:
+        # https://sdk.meltano.com/en/latest/classes/singer_sdk.RESTStream.html#singer_sdk.RESTStream.backoff_max_tries
+        # Default value is set to 5 in the docs, upgrading to 6 
         return 6

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -100,3 +100,6 @@ class HibobStream(RESTStream):
         """As needed, append or transform raw data to match expected structure."""
         # TODO: Delete this method if not needed.
         return row
+
+    def backoff_max_tries(self) -> int:
+        return 6


### PR DESCRIPTION
### Ticket ([DE-1934](https://potloc.atlassian.net/browse/DE-1934))

> We are experiencing issues with tap-hibob regarding *newly implemented rate limits*.
> 
> [https://apidocs.hibob.com/docs/rate-limit](https://apidocs.hibob.com/docs/rate-limit|smart-link) 
> 
> We will need to adapt our tap in order to have a longer cool-off time.

---
_from `tiguidou` with :heart:_


[DE-1934]: https://potloc.atlassian.net/browse/DE-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ