### PR TITLE
DE-2539 Hibob - Deprecation of employees endpoint - Create new stream for employees

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -25,14 +25,14 @@ plugins:
       start_date: '2010-01-01T00:00:00Z'
       backoff_max_tries: 6
     select:
-    # - company_fields.*
-    # - company_list_by_name.*
+    - company_fields.*
+    - company_list_by_name.*
     - company_field_list_items.*
-    # - employees.*
+    - employees.*
     - employees_search.*
-    # - employee_history.*
-    # - employee_work_history.*
-    # - employee_time_off.*
+    - employee_history.*
+    - employee_work_history.*
+    - employee_time_off.*
 
   - name: tap-hibob-finance
     inherit_from: tap-hibob

--- a/meltano.yml
+++ b/meltano.yml
@@ -27,6 +27,7 @@ plugins:
     select:
     # - company_fields.*
     # - company_list_by_name.*
+    - company_field_list_items.*
     # - employees.*
     - employees_search.*
     # - employee_history.*

--- a/meltano.yml
+++ b/meltano.yml
@@ -27,7 +27,8 @@ plugins:
     select:
     # - company_fields.*
     # - company_list_by_name.*
-    - employees.*
+    # - employees.*
+    - employees_search.*
     # - employee_history.*
     # - employee_work_history.*
     # - employee_time_off.*

--- a/meltano.yml
+++ b/meltano.yml
@@ -25,9 +25,9 @@ plugins:
       start_date: '2010-01-01T00:00:00Z'
       backoff_max_tries: 6
     select:
-    - company_fields.*
-    - company_list_by_name.*
-    # - employees.*
+    # - company_fields.*
+    # - company_list_by_name.*
+    - employees.*
     # - employee_history.*
     # - employee_work_history.*
     # - employee_time_off.*

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -79,16 +79,6 @@ class HibobStream(RESTStream):
             params["order_by"] = self.replication_key
         return params
 
-    def prepare_request_payload(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Optional[dict]:
-        """Prepare the data payload for the REST API request.
-
-        By default, no payload will be sent (return None).
-        """
-        # TODO: Delete this method if no payload is required. (Most REST APIs.)
-        return None
-
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result rows."""
         # TODO: Parse response body and return a set of records.

--- a/tap_hibob/client.py
+++ b/tap_hibob/client.py
@@ -1,10 +1,9 @@
 """REST client handling, including HibobStream base class."""
 
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, Optional
 
 import requests
-from memoization import cached
 from singer_sdk.authenticators import APIKeyAuthenticator, BasicAuthenticator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.streams import RESTStream

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import requests
 from requests import Response
-from singer_sdk import typing # JSON Schema typing helpers
 from typing import Any, Dict, Optional, Iterable
 
 

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -41,7 +41,6 @@ class EmployeesStream(HibobStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["showInactive"] = "true"
         params["humanReadable"] = "APPEND"
         return params
 
@@ -52,7 +51,9 @@ class EmployeesStream(HibobStream):
 
         By default, no payload will be sent (return None).
         """
-        return {}
+        return {
+            "showInactive": True
+        }
 
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -25,14 +25,16 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 
 class EmployeesStream(HibobStream):
+    # https://apidocs.hibob.com/reference/post_people-search
     """Define custom stream."""
 
     name = "employees"
-    path = "/v1/people"
+    path = "/v1/people/search"
     primary_keys = ["id"]
     records_jsonpath = "$.employees[*]"
     replication_method = "INCREMENTAL"
     replication_key = "creationDateTime"
+    rest_method = "POST"
     schema = Employees.schema
 
     def get_url_params(
@@ -40,8 +42,18 @@ class EmployeesStream(HibobStream):
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
         params["showInactive"] = "true"
-        params["includeHumanReadable"] = "true"
+        params["humanReadable"] = "APPEND"
         return params
+
+    def prepare_request_payload(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Optional[dict]:
+        """Prepare the data payload for the REST API request.
+
+        By default, no payload will be sent (return None).
+        """
+        return {}
+
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""

--- a/tap_hibob/streams.py
+++ b/tap_hibob/streams.py
@@ -23,12 +23,42 @@ from tap_hibob.schemas import (
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 
-
 class EmployeesStream(HibobStream):
-    # https://apidocs.hibob.com/reference/post_people-search
+    # Will be deprecated by March 2024. See here: https://apidocs.hibob.com/reference/get_people
     """Define custom stream."""
 
     name = "employees"
+    path = "/v1/people"
+    primary_keys = ["id"]
+    records_jsonpath = "$.employees[*]"
+    replication_method = "INCREMENTAL"
+    replication_key = "creationDateTime"
+    schema = Employees.schema
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params = super().get_url_params(context, next_page_token)
+        params["showInactive"] = "true"
+        params["includeHumanReadable"] = "true"
+        return params
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "employee_id": record["id"],
+        }
+
+class EmployeesSearchStream(HibobStream):
+    # https://apidocs.hibob.com/reference/post_people-search
+    """
+        This API returns a list of requested employees with requested fields.
+        The data is filtered based on the requested fields and access level of the logged-in user.
+        Only viewable categories are returned.
+        Supported user types: Service.
+    """
+
+    name = "employees_search"
     path = "/v1/people/search"
     primary_keys = ["id"]
     records_jsonpath = "$.employees[*]"
@@ -36,13 +66,6 @@ class EmployeesStream(HibobStream):
     replication_key = "creationDateTime"
     rest_method = "POST"
     schema = Employees.schema
-
-    def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Dict[str, Any]:
-        params = super().get_url_params(context, next_page_token)
-        params["humanReadable"] = "APPEND"
-        return params
 
     def prepare_request_payload(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -52,9 +75,29 @@ class EmployeesStream(HibobStream):
         By default, no payload will be sent (return None).
         """
         return {
-            "showInactive": True
+            "fields":[
+                "/root/displayName",
+                "/root/firstName",
+                "/root/fullName",
+                "/root/surname",
+                "/root/email",
+                "/root/creationDateTime",
+                "/personal/pronouns",
+                "/payroll/employment/type",
+                "/payroll/employment/contract",
+                "/work/customColumns/column_1644862416222",
+                "/work/customColumns/column_1644861659664",
+                "/work/custom/field_1651169416679",
+                "/work/title",
+                "/work/site",
+                "/work/department",
+                "/internal/terminationReason",
+                "/internal/probationEndDate",
+                "/internal/terminationDate"
+            ],
+            "showInactive": True,
+            "humanReadable": "APPEND"
         }
-
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""

--- a/tap_hibob/tap.py
+++ b/tap_hibob/tap.py
@@ -1,33 +1,9 @@
 """Hibob tap class."""
 
-from typing import List
-
-from singer_sdk import Stream, Tap
+from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-# TODO: Import your custom stream types here:
-from tap_hibob.streams import (
-    CompanyFieldListItems,
-    CompanyFieldsStream,
-    EmployeeEmploymentHistoryStream,
-    EmployeePayrollStream,
-    EmployeesStream,
-    EmployeeTimeOffStream,
-    EmployeeWorkHistoryStream,
-)
-
-# TODO: Compile a list of custom stream types here
-#       OR rewrite discover_streams() below with your custom logic.
-STREAM_TYPES = [
-    CompanyFieldsStream,
-    CompanyFieldListItems,
-    EmployeesStream,
-    EmployeeEmploymentHistoryStream,
-    EmployeeTimeOffStream,
-    EmployeePayrollStream,
-    EmployeeWorkHistoryStream,
-]
-
+from tap_hibob import streams
 
 class TapHibob(Tap):
     """Hibob tap class."""
@@ -78,10 +54,19 @@ class TapHibob(Tap):
         ),
     ).to_dict()
 
-    def discover_streams(self) -> List[Stream]:
-        """Return a list of discovered streams."""
-        return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+    def discover_streams(self) -> list[streams.HibobStream]:
+        """Return a list of discovered streams.
 
-
-if __name__ == "__main__":
-    TapHibob.cli()
+        Returns:
+            A list of discovered streams.
+        """
+        return [
+            streams.CompanyFieldsStream(self),
+            streams.CompanyFieldListItems(self),
+            streams.EmployeesStream(self),
+            streams.EmployeeEmploymentHistoryStream(self),
+            streams.EmployeeTimeOffStream(self),
+            streams.EmployeePayrollStream(self),
+            streams.EmployeeWorkHistoryStream(self),
+            streams.EmployeesSearchStream(self),
+        ]


### PR DESCRIPTION
### Ticket ([DE-2539](https://potloc.atlassian.net/browse/DE-2539))

> We’ll be following [this](https://apidocs.hibob.com/reference/post_people-search) documentation.
> We can also inspire ourselves from the [meltano documentation](https://sdk.meltano.com/en/latest/classes/singer_sdk.GraphQLStream.html#singer_sdk.GraphQLStream.rest_method) on GraphQl, as well as an example using post requests [here](https://github.com/potloc/tap-hubspot/pull/39/files).
> 
> With no payload:
> 
> 
> > ,
> 
> Note - this is much quicker, and could be leveraged for the child streams


---
_from `tiguidou` with :heart:_


[DE-2539]: https://potloc.atlassian.net/browse/DE-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ