### PR TITLE
DE-2544 Hibob - Bug fix - TypeError: 'type' object is not subscriptable

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -28,6 +28,7 @@ plugins:
       - company_fields.*
       - company_list_by_name.*
       - company_field_list_items.*
+      
       - employees.*
       - employees_search.*
       - employee_history.*

--- a/meltano.yml
+++ b/meltano.yml
@@ -28,7 +28,6 @@ plugins:
       - company_fields.*
       - company_list_by_name.*
       - company_field_list_items.*
-      
       - employees.*
       - employees_search.*
       - employee_history.*

--- a/meltano.yml
+++ b/meltano.yml
@@ -25,14 +25,14 @@ plugins:
       start_date: '2010-01-01T00:00:00Z'
       backoff_max_tries: 6
     select:
-    - company_fields.*
-    - company_list_by_name.*
-    - company_field_list_items.*
-    - employees.*
-    - employees_search.*
-    - employee_history.*
-    - employee_work_history.*
-    - employee_time_off.*
+      - company_fields.*
+      - company_list_by_name.*
+      - company_field_list_items.*
+      - employees.*
+      - employees_search.*
+      - employee_history.*
+      - employee_work_history.*
+      - employee_time_off.*
 
   - name: tap-hibob-finance
     inherit_from: tap-hibob

--- a/tap_hibob/tap.py
+++ b/tap_hibob/tap.py
@@ -1,6 +1,7 @@
 """Hibob tap class."""
 
 from singer_sdk import Tap
+from typing import List
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 from tap_hibob import streams
@@ -54,7 +55,7 @@ class TapHibob(Tap):
         ),
     ).to_dict()
 
-    def discover_streams(self) -> list[streams.HibobStream]:
+    def discover_streams(self) -> List[streams.HibobStream]:
         """Return a list of discovered streams.
 
         Returns:


### PR DESCRIPTION
### Ticket ([DE-2544](https://potloc.atlassian.net/browse/DE-2544))

> Getting error: 
> 
> > Cannot list the selected attributes: Catalog discovery failed: command '/project/.meltano/extractors/tap-hibob/venv/bin/tap-hibob', '--config', '/project/.meltano/run/tap-hibob/tap.5898f5ff-b7a9-4148-b11b-b906e113f0ce.config.json', '--discover' returned 1 with stderr:
> >  Traceback (most recent call last):
> >   File "/project/.meltano/extractors/tap-hibob/venv/bin/tap-hibob", line 5, in <module>
> >     from tap_hibob.tap import TapHibob
> >   File "/project/.meltano/extractors/tap-hibob/venv/lib/python3.8/site-packages/tap_hibob/tap.py", line 8, in <module>
> >     class TapHibob(Tap):
> >   File "/project/.meltano/extractors/tap-hibob/venv/lib/python3.8/site-packages/tap_hibob/tap.py", line 57, in TapHibob
> >     def discover_streams(self) -> liststreams.HibobStream:
> > TypeError: 'type' object is not subscriptable
> 
> Discovered that this is caused by a python issue:
> 
> [https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python](https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python|smart-link) 
> 
> 
> 
> Would be interesting to use this as a justification to bump our overall python version.


---
_from `tiguidou` with :heart:_


[DE-2544]: https://potloc.atlassian.net/browse/DE-2544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ